### PR TITLE
docs: Limitation with Arg methods with the required flatten

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ struct Cli {
 }
 ```
 
+## Limitations
+
+* [Argument methods][argument_methods] support with required clap(flatten) - see clap [derive reference][derive_reference]
+
+[argument_methods]: https://docs.rs/clap/latest/clap/struct.Arg.html#implementations
+[derive_reference]: https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md
+
 ## Relevant crates
 
 Other crates that might be useful for cargo plugins:


### PR DESCRIPTION
Provides documented on limitation(s) for #27 

And refers to underlying "clap_derive Arg methods with flattened" feature at https://github.com/clap-rs/clap/issues/3269