### PR TITLE
Support -F for feature

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -9,7 +9,12 @@ pub struct Features {
     #[clap(long)]
     /// Do not activate the `default` feature
     pub no_default_features: bool,
-    #[clap(long, require_value_delimiter = true, value_delimiter = ' ')]
+    #[clap(
+        short = 'F',
+        long,
+        require_value_delimiter = true,
+        value_delimiter = ' '
+    )]
     /// Space-separated list of features to activate
     pub features: Vec<String>,
 }


### PR DESCRIPTION
Recent cargo supports "-F" for the feature argument.

I'm not sure a) how long cargo has supported this b) which versions of the cargo CLI this crate targets, but I'm trying to use it with cargo 1.62.0.

