### PR TITLE
Omit serde/serde_json from lockfiles not using cargo_metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ pre-release-replacements = [
 [features]
 default = ["clap"]
 clap = ["dep:clap"]
-cargo_metadata = ["dep:cargo_metadata"]
+cargo_metadata = ["dep:cargo_metadata", "dep:serde", "dep:serde_json"]
 
 [dependencies]
 anstyle = "1.0.3"
@@ -121,8 +121,8 @@ cargo_metadata = { version = "0.19", optional = true }
 clap = { version = "4.4.1", default-features = false, features = ["std", "derive"], optional = true }
 
 [target.'cfg(any())'.dependencies]
-serde = "1.0.210"  # HACK: bad minimal dep in cargo_metadata
-serde_json = "1.0.133"  # HACK: bad minimal dep in cargo_metadata
+serde = { version = "1.0.210", optional = true }  # HACK: bad minimal dep in cargo_metadata
+serde_json = { version = "1.0.133", optional = true }  # HACK: bad minimal dep in cargo_metadata
 
 [[example]]
 name = "flags"


### PR DESCRIPTION
This will work just as well for forcing a good minimal version when clap-cargo's "cargo_metadata" feature is enabled, but it keeps `serde` and `serde_json` and `itoa` and `memchr` and `ryu` and `serde_derive` out of downstream Cargo.lock that wouldn't otherwise need them.