### PR TITLE
Fallback to workspace if workspace_default_members is unavailable

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -41,11 +41,14 @@ impl Workspace {
             Packages::from_flags(self.workspace || self.all, &self.exclude, &self.package);
         let workspace_members: std::collections::HashSet<_> =
             meta.workspace_members.iter().collect();
-        let workspace_default_members: std::collections::HashSet<_> =
-            meta.workspace_default_members.iter().collect();
+
         let base_ids: std::collections::HashSet<_> = match selection {
-            Packages::Default => workspace_default_members,
-            Packages::All => workspace_members,
+            // workspace_default_members requires cargo >= 1.71
+            Packages::Default if meta.workspace_default_members.is_available() =>  {
+                meta.workspace_default_members.iter().collect()
+            },
+            // If workspace_default_members is unavailable, default to workspace
+            Packages::All | Packages::Default => workspace_members,
             Packages::OptOut(_) => workspace_members, // Deviating from cargo by only checking workspace members
             Packages::Packages(patterns) => {
                 meta.packages


### PR DESCRIPTION
**NB: Draft because it requires a new release of https://github.com/oli-obk/cargo_metadata (which will include the new API's which can be used to check the presence of the the workspace_default_members field https://github.com/oli-obk/cargo_metadata/pull/282)**



When cargo_metadata is invoked with a Cargo version < 1.71, which doesn't support workspace default members, the workspace_default_members field in cargo_metadata will be empty. Dereferencing this field will then cause a panic. To prevent partition_packages to panic when used with older Cargo versions, we check the presence of the field, and if it is missing, we default to the workspace instead.

Do you agree that selecting the workspace, if workspace_default_members is unavailable, would be the right behaviour?

fixes #62

_See also: issue https://github.com/oli-obk/cargo_metadata/issues/254 "Don't panic from WorkspaceDefaultMembers?"_