### PR TITLE
fix: Don't force long help

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -12,10 +12,7 @@ pub struct Workspace {
     #[cfg_attr(feature = "clap", arg(long))]
     /// Process all packages in the workspace
     pub workspace: bool,
-    #[cfg_attr(
-        feature = "clap",
-        arg(long, hide_short_help(true), hide_long_help(true))
-    )]
+    #[cfg_attr(feature = "clap", arg(long, hide = true))]
     /// Process all packages in the workspace
     pub all: bool,
     #[cfg_attr(feature = "clap", arg(long, value_name = "SPEC"))]


### PR DESCRIPTION
The presence of `hide_long_help(true)` causes clap to show long help for `--help` because it doesn't realize the item is being hide in both long and short help.
Clap could detect that cause or we could use `hide` which is more what is intended.

See clap-rs/clap#5915